### PR TITLE
Fix the name of `only-given-run`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
       If all workflow runs must be successful. By default workflows that are skipped are ignored, but to require everything to be successful
       you can set this option.
     required: false
-  only-given-run-id:
+  only-given-run:
     description: |
       Only use the provided run ID's check suite. By default all check suites for the PR are considered when creating the comment.
     required: false

--- a/src/github-client.js
+++ b/src/github-client.js
@@ -15,7 +15,7 @@ module.exports = function createSimpleGithubClient(token, owner, repo) {
 
   return {
     /**
-     * @param  {string} runId The workflow run ID
+     * @param  {number} runId The workflow run ID
      * @return {WorkflowRun} An object containing the status, conclusion, and an array of pull request objects that
      *                       just has `number`.
      * @example const { status, conclusion, pullRequests } = await client.getWorkflowRun(runId);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const { context } = require("@actions/github");
 const action = require("./action");
 
 const token = core.getInput("token");
-const runId = core.getInput("run-id");
+const runId = parseInt(core.getInput("run-id"), 10);
 
 // If any value is given here, treat it as true. If it's not provided it'll be an empty string.
 const onlyGivenRun = core.getInput("only-given-run") === "" ? false : true;


### PR DESCRIPTION
In the action it was named `only-given-run-id` 🤦 Also parses the run ID as a number, since the filtering relies on `runId` being a number. 